### PR TITLE
Remove needs_ci label whenever a commit is pushed to a PR.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,6 +89,10 @@ for label in $labels; do
       echo "Removing label: $label"
       remove_label "$label"
       ;;
+    needs_ci)
+      echo "Removing label: $label"
+      remove_label "$label"
+      ;;
     needs_hotfix)
       echo "Setting has_hotfix_label=true"
       has_hotfix_label=true


### PR DESCRIPTION
Remove needs_ci label whenever a commit is pushed to a PR.