### PR TITLE
Don't remove needs_ci by default

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,10 +89,6 @@ for label in $labels; do
       echo "Removing label: $label"
       remove_label "$label"
       ;;
-    needs_ci)
-      echo "Removing label: $label"
-      remove_label "$label"
-      ;;
     needs_hotfix)
       echo "Setting has_hotfix_label=true"
       has_hotfix_label=true


### PR DESCRIPTION
Don't remove needs_ci label by default on pushing a new commit if already added