### PR TITLE
Removed automatic addition and removal of CI Lite for 3.13

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,6 +104,10 @@ for label in $labels; do
       add_label "needs_ci${alternate_python_version}"
       alt_needs_ci_label_present=true
       ;;
+    "ci_verified${alternate_python_version}:lite")
+      echo "Removing label: $label"
+      remove_label "$label"
+      ;;
     needs_ci)
       echo "needs_ci label is already present"
       needs_ci_label_present=true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,7 +83,6 @@ needs_ci_label_present=false
 needs_ci_lite_label_present=false
 shipit_label_present=false
 alt_needs_ci_label_present=false
-alt_needs_ci_lite_label_present=false
 
 for label in $labels; do
   case $label in
@@ -105,12 +104,6 @@ for label in $labels; do
       add_label "needs_ci${alternate_python_version}"
       alt_needs_ci_label_present=true
       ;;
-    "ci_verified${alternate_python_version}:lite")
-      echo "Removing label: $label and adding needs_ci${alternate_python_version}:lite"
-      remove_label "$label"
-      add_label "needs_ci${alternate_python_version}:lite"
-      alt_needs_ci_lite_label_present=true
-      ;;
     needs_ci)
       echo "needs_ci label is already present"
       needs_ci_label_present=true
@@ -122,10 +115,6 @@ for label in $labels; do
     "needs_ci${alternate_python_version}")
       echo "needs_ci${alternate_python_version} label is already present"
       alt_needs_ci_label_present=true
-      ;;
-    "needs_ci${alternate_python_version}:lite")
-      echo "needs_ci${alternate_python_version}:lite label is already present"
-      alt_needs_ci_lite_label_present=true
       ;;
     shipit)
       echo "shipit label is present"
@@ -147,9 +136,6 @@ if [[ "$shipit_label_present" = true ]]; then
 else
   if [[ "$needs_ci_lite_label_present" = false && "$needs_ci_label_present" = false ]]; then
     add_label "needs_ci:lite"
-  fi
-  if [[ "$alt_needs_ci_lite_label_present" = false && "$alt_needs_ci_label_present" = false ]]; then
-    add_label "needs_ci${alternate_python_version}:lite"
   fi
 fi
 


### PR DESCRIPTION
To prevent over use of github ci 3.13 instances, we're removing auto addition of 3.13 lite labels